### PR TITLE
don't set player to 0 after a win

### DIFF
--- a/R/c4game.R
+++ b/R/c4game.R
@@ -49,7 +49,6 @@ c4game <- setRefClass(
             # update the gamestate with player winner
             gamestate <<-
               paste("player", player, "wins")
-            player <<- 0
           } else {
             gamestate <<- "next"
             if (player == 1) {


### PR DESCRIPTION
The game currently sets player to 0 after a win. So when you call `getWinner` you get zero no matter who won. Doesn't look like this is used anywhere so I've taken it out.