### PR TITLE
Challenger Feature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,4 +16,6 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
 Imports: R6, methods
-Suggests: testthat
+Suggests: testthat,
+    c4dougbot2000
+Remotes: dougmet/c4dougbot2000

--- a/R/c4arena.R
+++ b/R/c4arena.R
@@ -6,6 +6,7 @@
 #' @param player2 Either an instance of a reference class or a reference class generator
 #' @param nrow Number of rows for the board
 #' @param ncol Number of columns for the board
+#' @param firstplayer numeric. 1 or 2, which player goes first?
 #'
 #' @return The game winner number. 1 or 2.
 #' @export
@@ -22,16 +23,17 @@
 #' p2 <- human$new(name = "Alice")
 #' c4arena(p1, p2)
 #' }
-c4arena <- function(player1, player2, nrow = 6, ncol = 7) {
+c4arena <- function(player1, player2, nrow = 6, ncol = 7, firstplayer = 1) {
 
-  game <- c4game$new(board = matrix(NA_integer_, nrow = nrow, ncol = ncol), player = 1, gamestate = "next")
+  game <- c4game$new(board = matrix(NA_integer_, nrow = nrow, ncol = ncol),
+                     player = firstplayer)
 
   # If it's a class generator create an instance
-  if(class(player1) == "refObjectGenerator") {
+  if(any(c("R6ClassGenerator", "refObjectGenerator") %in% class(player1))) {
     player1 <- player1$new(name = "player1")
   }
 
-  if(class(player2) == "refObjectGenerator") {
+  if(any(c("R6ClassGenerator", "refObjectGenerator") %in% class(player2))) {
     player2 <- player2$new(name = "player2")
   }
 
@@ -49,8 +51,8 @@ c4arena <- function(player1, player2, nrow = 6, ncol = 7) {
 
     game$dropToken(move)
     if( game$gamestate != "next" ){
-      cat(game$gamestate,"\n")
-      cat("Moves: ", counter, "\n")
+      #cat(game$gamestate,"\n")
+      #cat("Moves: ", counter, "\n")
       break
     }
   }

--- a/R/player-sequence.R
+++ b/R/player-sequence.R
@@ -1,4 +1,4 @@
-#' Random player for c4
+#' Sequence player for c4
 #'
 #' Give the bot the sequence and it will make the moves. Cyclic repetition means
 #' it never runs out of ideas.

--- a/man/c4arena.Rd
+++ b/man/c4arena.Rd
@@ -4,7 +4,7 @@
 \alias{c4arena}
 \title{Pit two players in a game of c4!}
 \usage{
-c4arena(player1, player2, nrow = 6, ncol = 7)
+c4arena(player1, player2, nrow = 6, ncol = 7, firstplayer = 1)
 }
 \arguments{
 \item{player1}{Either an instance of a reference class or a reference class generator}
@@ -14,6 +14,8 @@ c4arena(player1, player2, nrow = 6, ncol = 7)
 \item{nrow}{Number of rows for the board}
 
 \item{ncol}{Number of columns for the board}
+
+\item{firstplayer}{numeric. 1 or 2, which player goes first?}
 }
 \value{
 The game winner number. 1 or 2.

--- a/man/sequencePlayer-class.Rd
+++ b/man/sequencePlayer-class.Rd
@@ -4,7 +4,7 @@
 \name{sequencePlayer-class}
 \alias{sequencePlayer-class}
 \alias{sequencePlayer}
-\title{Random player for c4}
+\title{Sequence player for c4}
 \description{
 Give the bot the sequence and it will make the moves. Cyclic repetition means
 it never runs out of ideas.

--- a/tests/testthat/test-c4repl.R
+++ b/tests/testthat/test-c4repl.R
@@ -3,7 +3,7 @@ library(c4game)
 context("c4repl tests")
 
 test_that("that an unnatended game runs properly", {
-  expect_output(c4repl(0), "*Moves*")
+  expect_true(c4repl(0) %in% 0:2)
 })
 
 test_that("incorrect start-up params are checked", {

--- a/tests/testthat/test-challenger.R
+++ b/tests/testthat/test-challenger.R
@@ -1,0 +1,28 @@
+context("Beat the champion!")
+
+# Put your bot as the challenger and the champion as the old challenger.
+# It sounds backwards but if you win then you get merged!
+
+test_that("The champion is the best!", {
+
+  set.seed(14)
+
+  ngames <- 101
+  results <- integer(length = ngames)
+
+  starter <- sample(1:2, size = ngames, replace = TRUE)
+  for (i in seq.int(ngames)) {
+
+    challenger <- c4dougbot2000::dougbot2000$new()
+    champion <- randomPlayer$new()
+
+    results[i] <- c4arena(champion, challenger, firstplayer = starter[i])
+  }
+
+  tally <- table(results)
+  print(tally)
+
+  expect_gt(tally["2"], tally["1"], label = "You didn't win this time. Dust yourself off and go again!")
+
+})
+


### PR DESCRIPTION
Main feature is the test where you can test a new bot against the current champion

- c4arena now outputs the id of the winner (0 for stalemate) and not text.
- tests for c4repl adjusted to pick this up.
- support for R6 players. Probably will convert later.

Still todo. Could maybe give c4 arena a verbose option if you liked the messages. It also doesn't return the number of moves anymore. That could be useful somewhere.
